### PR TITLE
make datePublished a CustomDateFormat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2998,6 +2998,11 @@
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
       "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
     },
+    "dayjs": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
+    },
     "dbc-node-logger": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/dbc-node-logger/-/dbc-node-logger-2.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dataloader": "^2.0.0",
+    "dayjs": "^1.10.6",
     "dbc-node-logger": "^2.0.9",
     "esm": "^3.2.25",
     "express": "^4.17.1",

--- a/src/schema/scalars/index.js
+++ b/src/schema/scalars/index.js
@@ -1,7 +1,15 @@
 const { GraphQLScalarType } = require("graphql");
+// require all localizations
+require("dayjs/locale").forEach((el) => {
+  require(`dayjs/locale/${el.key}`);
+});
+const localizedFormat = require("dayjs/plugin/localizedFormat");
+const dayjs = require("dayjs");
+dayjs.extend(localizedFormat);
 
 export const typeDef = `
 scalar PaginationLimit
+scalar CustomDateFormat
 `;
 
 function inRange(value, min, max) {
@@ -26,6 +34,28 @@ export const resolvers = {
     parseLiteral(ast) {
       // gets invoked to parse client input that was passed inline in the query.
       return inRange(ast.value, 1, 100);
+    },
+  }),
+  CustomDateFormat: new GraphQLScalarType({
+    name: "CustomDateFormat",
+    description:
+      "Using dayjs to format dates and support localization. https://day.js.org/docs/en/display/format",
+    serialize(value) {
+      // gets invoked when serializing the result to send it back to a client.
+      if (typeof value === "string") {
+        return value;
+      }
+      return dayjs(value.date)
+        .locale(value.locale || "da")
+        .format(value.format || "YYYY");
+    },
+    parseValue(value) {
+      // gets invoked to parse client input that was passed through variables.
+      return value;
+    },
+    parseLiteral(ast) {
+      // gets invoked to parse client input that was passed inline in the query.
+      return value;
     },
   }),
 };


### PR DESCRIPTION
Jeg havde behov for at vise udgivelsesdato for artikler hvor man ikke er logget ind og dermed kan hente infomedia-artiklen ud.
Så derfor kigger jeg i nogle flere openformat-felter om der er en gyldig dato. Fallback er publicationYear.

Derudover har jeg rodet med en scalar CustomDateFormat, så man kan få en dato ud i valgtfrit format (som understøtter mange forskellige localizations)

Ændringen bør ikke brække api'et, dvs hvis man ikke giver et format med, så giver den årstallet tilbage